### PR TITLE
Set up Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project overview
+
+This is a Vue 3 + Vite single-page app ("DFM Invoice Creator", package name `invoice-generator`) for creating/printing invoices. It has two parts:
+
+- Frontend (repo root): Vue 3, Vite, Pinia, Vue Router, Tailwind v4, reka-ui/shadcn-vue components. Backed by Firebase (Auth, Firestore, Storage) and Algolia (invoice search). Standard commands live in `package.json` (`dev`, `build`, `test:unit`, `lint`, `format`) and `README.md`.
+- Firebase Functions (`functions/`): Node 22, TypeScript, `firebase-functions` v2 HTTP functions for admin/customer user creation. Standard commands live in `functions/package.json` (`build`, `lint`, `serve`, `deploy`).
+
+Dependencies for both `package.json` files are installed by the startup update script; you do not need to reinstall them.
+
+### Required environment variables (non-obvious gotcha)
+
+The frontend has NO local fallback and NO Firebase emulator wiring. `src/main.ts` calls `onAuthStateChanged` and `src/lib/firebase.ts` calls `getAuth()` at module load, BEFORE the app mounts. If the `VITE_FIREBASE_*` values are missing/invalid, Firebase throws `auth/invalid-api-key` and the app renders a completely blank page (no sign-in form). So valid Firebase config is mandatory just to see any UI.
+
+Create a `.env` (or `.env.local`) at the repo root (git-ignored via `*.local`) with, at minimum:
+
+- `VITE_FIREBASE_API_KEY`
+- `VITE_FIREBASE_AUTH_DOMAIN`
+- `VITE_FIREBASE_PROJECT_ID`
+- `VITE_FIREBASE_STORAGE_BUCKET`
+- `VITE_FIREBASE_MESSAGING_SENDER_ID`
+- `VITE_FIREBASE_APP_ID`
+- `VITE_FIREBASE_MEASUREMENT_ID`
+- `VITE_ALGOLIA_APP_ID`, `VITE_ALGOLIA_API_KEY` (invoice list/search on the dashboard)
+- `VITE_FIREBASE_FUNCTIONS_URL`, `VITE_FIREBASE_FUNCTIONS_SECRET` (used by `src/lib/firebase-auth.ts` for user-management calls)
+- `VITE_SITE_URL` (forgot-password redirect)
+
+Vite only exposes vars prefixed with `VITE_`. Restart `npm run dev` after editing env files.
+
+Signing in and creating an invoice also requires a valid Firebase Auth account on the configured project (there is no sign-up flow in the UI — accounts are provisioned via the `createAdminUser` / `createCustomerUser` functions or the Firebase console).
+
+### Lint status (pre-existing)
+
+`npm run lint` (root) and `npm run lint` (functions) currently report many pre-existing errors on a clean checkout (root: `vue/multi-word-component-names`, `no-explicit-any`, etc.; functions: `eslint-config-google` 2-space indent vs. the code's 4-space style). These are not environment problems — do not treat them as regressions introduced by your changes.
+
+### Notes
+
+- `npm run create-admin` references `scripts/createAdminUser.ts`, which does not exist in the repo; that script is not runnable as-is.
+- Egress is unrestricted in this environment, so Firebase/Algolia endpoints are reachable once credentials are supplied.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this Vue 3 + Vite invoice generator (frontend) and its Firebase Functions backend for future Cursor Cloud agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section documenting the two services, required `VITE_*` environment variables, and non-obvious gotchas.
- Configures the startup update script to install dependencies for both `package.json` files (`npm ci` at root and in `functions/`).

No application code was modified.

## Verification

Frontend (repo root):

| Command | Result |
| --- | --- |
| `npm ci` | installed 838 packages |
| `npm run test:unit -- --run` | 1 passed |
| `npm run build` (type-check + vite build) | built successfully |
| `npm run lint` | runs; reports pre-existing lint errors (code style) |
| `npm run dev` | serves on `http://localhost:5173/` (HTTP 200) |

Functions (`functions/`):

| Command | Result |
| --- | --- |
| `npm ci` | installed 698 packages |
| `npm run build` (`tsc`) | built successfully |
| `npm run lint` | runs; reports pre-existing lint errors (code style) |

## Blocked: hello-world (create an invoice)

The dev server runs, but the app renders a blank page without valid Firebase config: `src/main.ts` runs `onAuthStateChanged` and `src/lib/firebase.ts` calls `getAuth()` at module load, throwing `auth/invalid-api-key` before mount. Completing the hello-world flow (sign in → create an invoice) requires the real `VITE_FIREBASE_*` / `VITE_ALGOLIA_*` secrets plus a test login for the Firebase project. There is no Firebase emulator wiring, and adding one would require modifying app code.

[Dev server running; app blank due to missing Firebase credentials (auth/invalid-api-key)](https://cursor.com/agents/bc-46613bde-76fe-4f9c-b677-04a69c442c6a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdev_server_firebase_error.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46613bde-76fe-4f9c-b677-04a69c442c6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46613bde-76fe-4f9c-b677-04a69c442c6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

